### PR TITLE
Update to IntelliJ 2025.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN  \
   && rm -rf /var/lib/apt/lists/* \
   && useradd -ms /bin/bash developer
   
-ARG IDEA_VERSION=2024.2
-ARG IDEA_BUILD=2024.2.1
+ARG IDEA_VERSION=2025.2
+ARG IDEA_BUILD=2025.2.1
 ARG idea_local_dir=.IdeaIC${IDEA_VERSION}
 
 WORKDIR /opt/idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM debian
 
 RUN  \
-  apt-get update && apt-get install --no-install-recommends -y \
+  apt-get update -qq && apt-get install -qq --no-install-recommends -y \
   default-jdk gcc git openssh-client less curl \
   libxtst-dev libxext-dev libxrender-dev libfreetype6-dev \
   libfontconfig1 libgtk2.0-0 libxslt1.1 libxxf86vm1 \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-Run `docker run -v $PWD:/github/workspace ghcr.io/leventebajczi/intellij-format:latest "*.java,*.kts,*.kt" "" "./<intellij-stylesheet.xml>"` to format the current working directtory's java, kts and kt files according to the stylesheet.
+# IntelliJ IDEA Foramt
 
+Run `docker run -v $PWD:/github/workspace ghcr.io/leventebajczi/intellij-format:latest "*.java,*.kts,*.kt" "" "./<intellij-stylesheet.xml>"` to format the current working directory's java, kts, and kt files according to the stylesheet.
 
 To use as an action:
 
-```
+```yaml
     - name: Reformat
       uses: leventeBajczi/intellij-idea-format@v1.0
       with:
@@ -18,4 +19,3 @@ To use as an action:
         branch: "code-reformat"
         title: '[AutoPR] Reformatted code'
 ```
-


### PR DESCRIPTION
This PR updates IntelliJ to 2025.2

Also refines README.md and slightly reduces output during build.

I did not add a [CHANGELOG.md](https://keepachangelog.com/en/1.1.0/) 😅