### PR TITLE
Update to 2025.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,21 @@ RUN  \
   && rm -rf /var/lib/apt/lists/* \
   && useradd -ms /bin/bash developer
   
-ARG IDEA_VERSION=2025.2
-ARG IDEA_BUILD=2025.2.1
-ARG idea_local_dir=.IdeaIC${IDEA_VERSION}
+ARG IDEA_VERSION=2025.3
+ARG IDEA_BUILD=2025.3
+ARG idea_local_dir=.Idea${IDEA_VERSION}
 
 WORKDIR /opt/idea
 
 RUN echo "Preparing IntelliJ IDEA ${IDEA_BUILD} ..." \
-  && export idea_source=https://download.jetbrains.com/idea/ideaIC-${IDEA_BUILD}.tar.gz \
+  && export idea_source=https://download.jetbrains.com/idea/idea-${IDEA_BUILD}.tar.gz \
   && echo "Downloading ${idea_source} ..." \
   && curl -fsSL $idea_source -o /opt/idea/installer.tgz \
   && tar --strip-components=1 -xzf installer.tgz \
   && rm installer.tgz
 
 USER developer
-ENV HOME /home/developer
+ENV HOME=/home/developer
 
 RUN mkdir /home/developer/.Idea \
   && ln -sf /home/developer/.Idea /home/developer/$idea_local_dir


### PR DESCRIPTION
JetBrains merged the Community Edition into the Ultimate Edition - therefore the "larger" diff.

https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/

----

Tested in the docker container - works

```terminal
root@e4b7b65c6348:/github/workspace# /opt/idea/bin/format.sh -m "*.java" -dry -r -s .idea/codeStyles/Project.xml .
...
2025-12-11 12:28:32,069 [    987]   WARN - o.j.n.l.LinuxTrustedCertificatesUtil - Unable to read certificates from directory /etc/ssl/certs: Malformed input or input contains unmappable characters: /etc/ssl/certs/NetLock_Arany_=Class_Gold=_F??tan??s??tv??ny.pem
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /etc/ssl/certs/NetLock_Arany_=Class_Gold=_F??tan??s??tv??ny.pem
        at java.base/sun.nio.fs.UnixPath.encode(UnixPath.java:130)
        at java.base/sun.nio.fs.UnixPath.<init>(UnixPath.java:77)
        at java.base/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:312)
        at com.intellij.platform.core.nio.fs.DelegatingFileSystem.getPath(DelegatingFileSystem.java:94)
        at com.intellij.platform.core.nio.fs.MultiRoutingFsPath.getCurrentDelegate(MultiRoutingFsPath.java:42)
        at com.intellij.platform.core.nio.fs.MultiRoutingFileSystemProvider.toDelegatePath(MultiRoutingFileSystemProvider.java:268)
        at com.intellij.platform.core.nio.fs.TracingFileSystemProvider.readAttributes(TracingFileSystemProvider.java:252)
        at java.base/java.nio.file.spi.FileSystemProvider.readAttributesIfExists(FileSystemProvider.java:1270)
        at java.base/java.nio.file.Files.isRegularFile(Files.java:2359)
        at org.jetbrains.nativecerts.linux.LinuxTrustedCertificatesUtil.tryReadFromDirectory(LinuxTrustedCertificatesUtil.java:78)
        at org.jetbrains.nativecerts.linux.LinuxTrustedCertificatesUtil.getSystemCertificates(LinuxTrustedCertificatesUtil.java:51)
        at org.jetbrains.nativecerts.NativeTrustedCertificates.getCustomOsSpecificTrustedCertificates(NativeTrustedCertificates.java:34)
        at com.intellij.util.net.ssl.OsCertificatesServiceImpl.getCustomOsSpecificTrustedCertificates(OsCertificatesServiceImpl.java:30)
        at com.intellij.util.net.ssl.ConfirmingTrustManager.getOperatingSystemTrustManager(ConfirmingTrustManager.java:100)
        at com.intellij.util.net.ssl.ConfirmingTrustManager.getSystemTrustManagers(ConfirmingTrustManager.java:67)
        at com.intellij.util.net.ssl.ConfirmingTrustManager.createForStorage(ConfirmingTrustManager.java:61)
        at com.intellij.util.net.ssl.CertificateManager.trustManager_delegate$lambda$0(CertificateManager.kt:66)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
        at com.intellij.util.net.ssl.CertificateManager.getTrustManager(CertificateManager.kt:65)
        at com.intellij.util.net.ssl.CertificateManager.computeSslContext(CertificateManager.kt:287)
        at com.intellij.util.net.ssl.CertificateManager.sslContext_delegate$lambda$0(CertificateManager.kt:85)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
        at com.intellij.util.net.ssl.CertificateManager.getSslContext(CertificateManager.kt:85)
        at com.intellij.util.net.ssl.CertificateManager$1.invokeSuspend(CertificateManager.kt:94)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:610)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runDefaultDispatcherTask(CoroutineScheduler.kt:1194)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:906)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:775)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:762)

2025-12-11 12:28:43,203 [  12121]   WARN - #c.i.o.a.ApplicationManager - Cannot execute background write action in 10 seconds. Thread dump is stored in file:///root/.cache/JetBrains/IntelliJIdea2025.3/log/bg-wa/thread-dump-2041811815.txt
Checking /github/workspace/.jbang/CheckoutPR.java...Formatted well
Checking /github/workspace/.jbang/CloneJabRef.java...Formatted well
Checking /github/workspace/.jbang/JabKitLauncher.java...Formatted well
Checking /github/workspace/.jbang/JabLsLauncher.java...Formatted well
Checking /github/workspace/.jbang/JabSrvLauncher.java...Formatted well
...
```